### PR TITLE
enactor-em: per-component rmiServerHost override (ENACTOR_RMI_SERVERH…

### DIFF
--- a/charts/enactor-em/Chart.yaml
+++ b/charts/enactor-em/Chart.yaml
@@ -4,7 +4,7 @@ description: Enactor EM-servers
 
 type: application
 
-version: 0.5.9
+version: 0.5.10
 appVersion: "1.0"
 
 maintainers:

--- a/charts/enactor-em/templates/statefulset.yaml
+++ b/charts/enactor-em/templates/statefulset.yaml
@@ -61,10 +61,18 @@ spec:
           env:
             {{ include "db.env" $ | nindent 12 }}
 
+            # RMI hands clients an absolute host:port for the callback. Default is
+            # the pod IP (reachable in-cluster). Set components.<c>.rmiServerHost to
+            # advertise a routable address instead (e.g. a tsproxy VIP) when the
+            # component's RMI is reached from outside the cluster.
             - name: ENACTOR_RMI_SERVERHOST
+              {{- if $comp.rmiServerHost }}
+              value: {{ $comp.rmiServerHost | quote }}
+              {{- else }}
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+              {{- end }}
 
           envFrom:
             - configMapRef:

--- a/charts/enactor-em/tests/__snapshot__/serviceaccounts_test.yaml.snap
+++ b/charts/enactor-em/tests/__snapshot__/serviceaccounts_test.yaml.snap
@@ -9,7 +9,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ema
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: ema
   2: |
     apiVersion: v1
@@ -21,7 +21,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: emp
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: emp
   3: |
     apiVersion: v1
@@ -33,7 +33,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: emr
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: emr
   4: |
     apiVersion: v1
@@ -45,7 +45,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ems
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: ems
   5: |
     apiVersion: v1
@@ -57,5 +57,5 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tms
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: tms

--- a/charts/enactor-em/tests/__snapshot__/services_test.yaml.snap
+++ b/charts/enactor-em/tests/__snapshot__/services_test.yaml.snap
@@ -8,7 +8,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ema
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: ema
     spec:
       ports:
@@ -29,7 +29,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: emp
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: emp
     spec:
       ports:
@@ -70,7 +70,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: emr
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: emr
     spec:
       ports:
@@ -91,7 +91,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ems
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: ems
     spec:
       ports:
@@ -112,7 +112,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tms
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: tms
     spec:
       ports:

--- a/charts/enactor-em/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/charts/enactor-em/tests/__snapshot__/statefulset_test.yaml.snap
@@ -8,7 +8,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ema
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: ema
     spec:
       replicas: 1
@@ -20,8 +20,8 @@ matches the rendered snapshot:
       template:
         metadata:
           annotations:
-            checksum/common: 566652dda2f57947b4eb7ed84f44e9e86748a92927dee65be5df323a3e8cf92f
-            checksum/ema: adfece8a64e2bc6b16bba4adbb65ace23042880f1212220505aa309133bc16fc
+            checksum/common: 051e612b821edbc7b332e43797385c2abffa080fc0ebd911faf19908bb3201c8
+            checksum/ema: 2d69791f7bd02e205afb5cb8fd4a9f3cd78d6dfc9871fa1d8deb6ba02bf56243
           labels:
             app.kubernetes.io/instance: em
             app.kubernetes.io/name: ema
@@ -134,7 +134,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: emp
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: emp
     spec:
       replicas: 1
@@ -146,8 +146,8 @@ matches the rendered snapshot:
       template:
         metadata:
           annotations:
-            checksum/common: 566652dda2f57947b4eb7ed84f44e9e86748a92927dee65be5df323a3e8cf92f
-            checksum/emp: 765c735991e7ab8769e92eca1ea349a39e6b323e21ab4925c62dd1deec6d72d4
+            checksum/common: 051e612b821edbc7b332e43797385c2abffa080fc0ebd911faf19908bb3201c8
+            checksum/emp: 3688a0f18cd2762a73507c2cf2afff8aefdc76b754907074897411c63c61f233
           labels:
             app.kubernetes.io/instance: em
             app.kubernetes.io/name: emp
@@ -272,7 +272,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: emr
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: emr
     spec:
       replicas: 1
@@ -284,8 +284,8 @@ matches the rendered snapshot:
       template:
         metadata:
           annotations:
-            checksum/common: 566652dda2f57947b4eb7ed84f44e9e86748a92927dee65be5df323a3e8cf92f
-            checksum/emr: b2d366418c809f51e24a0b60641966f32a77fbd6db71f9119360c3c9b13521f8
+            checksum/common: 051e612b821edbc7b332e43797385c2abffa080fc0ebd911faf19908bb3201c8
+            checksum/emr: c5c6f00d67728948b18d2ae8244ec658ccd9bec4658c128a41745c0340c45f68
           labels:
             app.kubernetes.io/instance: em
             app.kubernetes.io/name: emr
@@ -395,7 +395,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ems
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: ems
     spec:
       replicas: 1
@@ -407,8 +407,8 @@ matches the rendered snapshot:
       template:
         metadata:
           annotations:
-            checksum/common: 566652dda2f57947b4eb7ed84f44e9e86748a92927dee65be5df323a3e8cf92f
-            checksum/ems: b11cae1e6cad092eba6a46ba023e39b9831065b3825643365afc193e27d3d446
+            checksum/common: 051e612b821edbc7b332e43797385c2abffa080fc0ebd911faf19908bb3201c8
+            checksum/ems: 78daf8bf85b22a6bd931b377fd8e7ab7ad91e7993be0116e39b098d0f06617a9
           labels:
             app.kubernetes.io/instance: em
             app.kubernetes.io/name: ems
@@ -518,7 +518,7 @@ matches the rendered snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: tms
         app.kubernetes.io/version: "1.0"
-        helm.sh/chart: enactor-em-0.5.9
+        helm.sh/chart: enactor-em-0.5.10
       name: tms
     spec:
       replicas: 1
@@ -530,8 +530,8 @@ matches the rendered snapshot:
       template:
         metadata:
           annotations:
-            checksum/common: 566652dda2f57947b4eb7ed84f44e9e86748a92927dee65be5df323a3e8cf92f
-            checksum/tms: 5f3b4f6034fe7343f395590f423a1d32629a0b8d8044e571678926f429b35584
+            checksum/common: 051e612b821edbc7b332e43797385c2abffa080fc0ebd911faf19908bb3201c8
+            checksum/tms: be767a245959047079692dde8faceb44007491920ca14c8777c297a2186520e1
           labels:
             app.kubernetes.io/instance: em
             app.kubernetes.io/name: tms

--- a/charts/enactor-em/tests/statefulset_test.yaml
+++ b/charts/enactor-em/tests/statefulset_test.yaml
@@ -91,13 +91,34 @@ tests:
             name: PORT
             value: "39832"
 
-  - it: sets ENACTOR_RMI_SERVERHOST from the pod IP
+  - it: defaults ENACTOR_RMI_SERVERHOST to the pod IP when rmiServerHost is unset
     template: templates/statefulset.yaml
     documentSelector:
       path: metadata.name
       value: emp
     asserts:
       - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENACTOR_RMI_SERVERHOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+
+  - it: components.<c>.rmiServerHost overrides ENACTOR_RMI_SERVERHOST with a literal value
+    template: templates/statefulset.yaml
+    set:
+      components.emp.rmiServerHost: 10.16.2.20
+    documentSelector:
+      path: metadata.name
+      value: emp
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENACTOR_RMI_SERVERHOST
+            value: "10.16.2.20"
+      - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: ENACTOR_RMI_SERVERHOST

--- a/charts/enactor-em/values.yaml
+++ b/charts/enactor-em/values.yaml
@@ -107,6 +107,10 @@ components:
         initialDelaySeconds: 20
   emp:
     image: emp
+    # Optional: advertise a routable RMI host (ENACTOR_RMI_SERVERHOST) instead of
+    # the pod IP — set when emp's RMI is reached from outside the cluster via a
+    # proxy VIP. Defaults to status.podIP when unset.
+    # rmiServerHost: "10.0.0.1"
     dependsOn:
       service: em-db
       port: 3306
@@ -224,7 +228,7 @@ enactor:
   # Process set this Estate Manager belongs to (ENACTOR_COMMON_PROCESSSET).
   processSet: Enactor
   # Process-connections definition id (ENACTOR_PROCESSCONNECTIONS_DEFINITIONID).
-  processConnectionsDefinitionId: PosEstateManager
+  processConnectionsDefinitionId: StandardPosEstateManager
   # Base URLs of the card-authorisation (EFT) endpoints CARDAUTH1..4. These are
   # independent endpoints (typically the same, but can differ for redundancy).
   cardAuth1UrlBase: http://em-cardauth:39856


### PR DESCRIPTION
Allow components.<c>.rmiServerHost to advertise a routable RMI host instead of status.podIP, for components reached from outside the cluster via a proxy VIP. Defaults to the pod IP when unset, so existing deployments are unchanged.

Bump chart to 0.5.10.